### PR TITLE
increase performance of crc32

### DIFF
--- a/lib/crc32.js
+++ b/lib/crc32.js
@@ -8,21 +8,29 @@ class TsCrc32 {
     }
 
     decode() {
+        return TsCrc32.calc(this.buffer);
+    }
+
+    decodeBuffer() {
+        return TsCrc32.calcToBuffer(this.buffer);
+    }
+
+    static calc(buffer) {
         let crc = -1;
 
-        for (let byte of this.buffer) {
-            crc = (crc << 8) ^ crc32Table[(crc >>> 24) ^ byte];
+        for (let i = 0, l = buffer.length; i < l; i++) {
+            crc = (crc << 8) ^ crc32Table[(crc >>> 24) ^ buffer[i]];
         }
 
         return crc;
     }
 
-    decodeBuffer() {
-        let buffer = Buffer.alloc(4);
+    static calcToBuffer(buffer) {
+        let result = Buffer.alloc(4);
 
-        buffer.writeInt32BE(this.decode(), 0);
+        result.writeInt32BE(TsCrc32.calc(buffer), 0);
 
-        return buffer;
+        return result;
     }
 }
 

--- a/lib/table/bat.js
+++ b/lib/table/bat.js
@@ -10,7 +10,7 @@ class TsTableBat {
     }
 
     decode() {
-        if (new TsCrc32(this.buffer).decode() !== 0) return null;
+        if (TsCrc32.calc(this.buffer) !== 0) return null;
 
         let reader = new TsReader(this.buffer);
         let objBat = {};

--- a/lib/table/cat.js
+++ b/lib/table/cat.js
@@ -10,7 +10,7 @@ class TsTableCat {
     }
 
     decode() {
-        if (new TsCrc32(this.buffer).decode() !== 0) return null;
+        if (TsCrc32.calc(this.buffer) !== 0) return null;
 
         let reader = new TsReader(this.buffer);
         let objCat = {};

--- a/lib/table/cdt.js
+++ b/lib/table/cdt.js
@@ -10,7 +10,7 @@ class TsTableCdt {
     }
 
     decode() {
-        if (new TsCrc32(this.buffer).decode() !== 0) return null;
+        if (TsCrc32.calc(this.buffer) !== 0) return null;
 
         let reader = new TsReader(this.buffer);
         let objCdt = {};

--- a/lib/table/dsmcc.js
+++ b/lib/table/dsmcc.js
@@ -97,7 +97,7 @@ class TsTableDsmcc {
     }
 
     decode() {
-        if (this.buffer[1] >> 7 === 1 && new TsCrc32(this.buffer).decode() !== 0) return null;
+        if (this.buffer[1] >> 7 === 1 && TsCrc32.calc(this.buffer) !== 0) return null;
 
         let reader = new TsReader(this.buffer);
         let objDsmcc = {};

--- a/lib/table/eit.js
+++ b/lib/table/eit.js
@@ -10,7 +10,7 @@ class TsTableEit {
     }
 
     decode() {
-        if (new TsCrc32(this.buffer).decode() !== 0) return null;
+        if (TsCrc32.calc(this.buffer) !== 0) return null;
 
         let reader = new TsReader(this.buffer);
         let objEit = {};

--- a/lib/table/nit.js
+++ b/lib/table/nit.js
@@ -10,7 +10,7 @@ class TsTableNit {
     }
 
     decode() {
-        if (new TsCrc32(this.buffer).decode() !== 0) return null;
+        if (TsCrc32.calc(this.buffer) !== 0) return null;
 
         let reader = new TsReader(this.buffer);
         let objNit = {};

--- a/lib/table/pat.js
+++ b/lib/table/pat.js
@@ -10,7 +10,7 @@ class TsTablePat {
     }
 
     decode() {
-        if (new TsCrc32(this.buffer).decode() !== 0) return null;
+        if (TsCrc32.calc(this.buffer) !== 0) return null;
 
         let reader = new TsReader(this.buffer);
         let objPat = {};
@@ -82,7 +82,7 @@ class TsTablePat {
         writer.position = pos << 3;
 
         pos = writer.position >> 3;
-        writer.writeBytes(4, new TsCrc32(this.buffer.slice(0, pos)).decodeBuffer());
+        writer.writeBytes(4, TsCrc32.calcToBuffer(this.buffer.slice(0, pos)));
 
         return this.buffer.slice(0, pos + 4);
     }

--- a/lib/table/pmt.js
+++ b/lib/table/pmt.js
@@ -10,7 +10,7 @@ class TsTablePmt {
     }
 
     decode() {
-        if (new TsCrc32(this.buffer).decode() !== 0) return null;
+        if (TsCrc32.calc(this.buffer) !== 0) return null;
 
         let reader = new TsReader(this.buffer);
         let objPmt = {};

--- a/lib/table/sdt.js
+++ b/lib/table/sdt.js
@@ -10,7 +10,7 @@ class TsTableSdt {
     }
 
     decode() {
-        if (new TsCrc32(this.buffer).decode() !== 0) return null;
+        if (TsCrc32.calc(this.buffer) !== 0) return null;
 
         let reader = new TsReader(this.buffer);
         let objSdt = {};

--- a/lib/table/sdtt.js
+++ b/lib/table/sdtt.js
@@ -10,7 +10,7 @@ class TsTableSdtt {
     }
 
     decode() {
-        if (new TsCrc32(this.buffer).decode() !== 0) return null;
+        if (TsCrc32.calc(this.buffer) !== 0) return null;
 
         let reader = new TsReader(this.buffer);
         let objSdtt = {};

--- a/lib/table/sit.js
+++ b/lib/table/sit.js
@@ -10,7 +10,7 @@ class TsTableSit {
     }
 
     decode() {
-        if (new TsCrc32(this.buffer).decode() !== 0) return null;
+        if (TsCrc32.calc(this.buffer) !== 0) return null;
 
         let reader = new TsReader(this.buffer);
         let objSit = {};

--- a/lib/table/tot.js
+++ b/lib/table/tot.js
@@ -10,7 +10,7 @@ class TsTableTot {
     }
 
     decode() {
-        if (new TsCrc32(this.buffer).decode() !== 0) return null;
+        if (TsCrc32.calc(this.buffer) !== 0) return null;
 
         let reader = new TsReader(this.buffer);
         let objTot = {};


### PR DESCRIPTION
誤差の範囲内ですがCRC32にかかる処理を最適化してみました
TsCrc32の古いメソッドは互換性のため残しています

#### (参考) 比較
before:
```
t:\git\node-aribts\test>node test.js gr.ts

Done - 612428424 of 612428424 [100%]
load: 11210.350ms
info { '0': { packet: 3546, drop: 0, scrambling: 0 },
  '1': { packet: 36, drop: 0, scrambling: 0 },
  '16': { packet: 355, drop: 0, scrambling: 0 },
  '17': { packet: 177, drop: 0, scrambling: 0 },
  '18': { packet: 20993, drop: 0, scrambling: 0 },
  '20': { packet: 71, drop: 0, scrambling: 0 },
  '35': { packet: 218, drop: 0, scrambling: 0 },
  '36': { packet: 355, drop: 0, scrambling: 0 },
  '39': { packet: 946, drop: 0, scrambling: 0 },
  '40': { packet: 10, drop: 0, scrambling: 0 },
  '41': { packet: 9, drop: 0, scrambling: 0 },
  '256': { packet: 3163561, drop: 0, scrambling: 0 },
  '272': { packet: 50561, drop: 0, scrambling: 0 },
  '496': { packet: 7093, drop: 0, scrambling: 0 },
  '511': { packet: 6125, drop: 0, scrambling: 0 },
  '3585': { packet: 3542, drop: 0, scrambling: 0 } }
```
after:
```
t:\git\node-aribts\test>node test.js gr.ts

Done - 612428424 of 612428424 [100%]
load: 10062.989ms
...
```